### PR TITLE
Add DSA CLI dashboard and scaffolding

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+import { runCli } from './src/cli/index.js'
+
+function ignoreBrokenPipe(stream) {
+  stream.on('error', (error) => {
+    if (error?.code === 'EPIPE') {
+      process.exit(0)
+    }
+
+    throw error
+  })
+}
+
+ignoreBrokenPipe(process.stdout)
+ignoreBrokenPipe(process.stderr)
+
+try {
+  await runCli(process.argv.slice(2))
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`CLI error: ${message}`)
+  process.exitCode = 1
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "",
   "main": "index.js",
   "type": "module",
+  "bin": {
+    "dsa": "./cli.js"
+  },
   "scripts": {
     "pretest:type-check": "tsc -p . --noEmit",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "cli": "node cli.js"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,25 @@ npm install
 npm test
 ```
 
+## CLI dashboard and scaffolding
+
+Run the repository CLI through npm:
+
+```
+npm run cli -- dashboard
+```
+
+Generate starter files for a new problem or data structure:
+
+```
+npm run cli -- generate --track algorithms --category arrays --problem "Common Child" --language typescript
+npm run cli -- generate --track data-structures --problem "Binary Tree" --language python
+```
+
+You can also expose the `dsa` command locally with `npm link`, then use `dsa dashboard` or `dsa generate ...`.
+
+Generated scaffolds include an `@dsa-cli-status scaffold` marker. Remove that marker once the implementation is complete so the dashboard counts the work as solved.
+
 ## Algorithms (25/ 168)
 
 | Name                                                      | Tags                    | Solution                                                                                                                            |

--- a/src/cli/catalog.js
+++ b/src/cli/catalog.js
@@ -1,0 +1,178 @@
+import fs from 'fs'
+import path from 'path'
+
+import { CATALOG_PATH } from './constants.js'
+import {
+  normalizeCategoryInput,
+  normalizeTrackInput,
+  slugify,
+  titleFromSlug,
+} from './normalize.js'
+
+function assertNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid CLI catalog: ${label} must be a non-empty string`)
+  }
+}
+
+function assertCatalogShape(catalog) {
+  if (!catalog?.tracks?.algorithms?.categories) {
+    throw new Error('Invalid CLI catalog: missing algorithm categories')
+  }
+
+  if (!catalog?.tracks?.['data-structures']?.items) {
+    throw new Error('Invalid CLI catalog: missing data-structure items')
+  }
+
+  if (!Array.isArray(catalog.tracks.algorithms.categories)) {
+    throw new Error('Invalid CLI catalog: algorithm categories must be an array')
+  }
+
+  if (!Array.isArray(catalog.tracks['data-structures'].items)) {
+    throw new Error('Invalid CLI catalog: data-structure items must be an array')
+  }
+
+  for (const category of catalog.tracks.algorithms.categories) {
+    assertNonEmptyString(category.slug, 'algorithm category slug')
+    assertNonEmptyString(category.title, 'algorithm category title')
+
+    if (!Array.isArray(category.items)) {
+      throw new Error(
+        `Invalid CLI catalog: ${category.slug} items must be an array`
+      )
+    }
+
+    for (const item of category.items) {
+      assertNonEmptyString(item.slug, `${category.slug} item slug`)
+      assertNonEmptyString(item.title, `${category.slug} item title`)
+    }
+  }
+
+  for (const item of catalog.tracks['data-structures'].items) {
+    assertNonEmptyString(item.slug, 'data-structure slug')
+    assertNonEmptyString(item.title, 'data-structure title')
+  }
+}
+
+export function loadCatalog(catalogPath = CATALOG_PATH) {
+  if (!fs.existsSync(catalogPath)) {
+    throw new Error(
+      `Missing CLI catalog at ${catalogPath}. Recreate src/cli/problem-catalog.json before running the CLI.`
+    )
+  }
+
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'))
+  assertCatalogShape(catalog)
+  return catalog
+}
+
+export function saveCatalog(catalog, catalogPath = CATALOG_PATH) {
+  assertCatalogShape(catalog)
+  fs.mkdirSync(path.dirname(catalogPath), { recursive: true })
+  fs.writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`)
+}
+
+export function getAlgorithmCategories(catalog) {
+  return catalog.tracks.algorithms.categories
+}
+
+export function getDataStructureItems(catalog) {
+  return catalog.tracks['data-structures'].items
+}
+
+export function findAlgorithmCategory(catalog, categorySlug) {
+  const normalizedCategorySlug = normalizeCategoryInput(categorySlug)
+
+  return (
+    getAlgorithmCategories(catalog).find(
+      (category) => category.slug === normalizedCategorySlug
+    ) ?? null
+  )
+}
+
+export function ensureAlgorithmCategory(
+  catalog,
+  categorySlug,
+  categoryTitle = titleFromSlug(categorySlug)
+) {
+  const existingCategory = findAlgorithmCategory(catalog, categorySlug)
+
+  if (existingCategory) {
+    return existingCategory
+  }
+
+  const category = {
+    slug: normalizeCategoryInput(categorySlug),
+    title: categoryTitle,
+    items: [],
+  }
+
+  getAlgorithmCategories(catalog).push(category)
+  return category
+}
+
+export function findAlgorithmItem(catalog, categorySlug, itemNameOrSlug) {
+  const category = findAlgorithmCategory(catalog, categorySlug)
+
+  if (!category) {
+    return null
+  }
+
+  const itemSlug = slugify(itemNameOrSlug)
+
+  return category.items.find((item) => item.slug === itemSlug) ?? null
+}
+
+export function ensureAlgorithmItem(catalog, { categorySlug, categoryTitle, title, tags }) {
+  const category = ensureAlgorithmCategory(catalog, categorySlug, categoryTitle)
+  const itemSlug = slugify(title)
+  const existingItem = category.items.find((item) => item.slug === itemSlug)
+
+  if (existingItem) {
+    return existingItem
+  }
+
+  const item = {
+    slug: itemSlug,
+    title,
+    tags: tags ?? [category.title],
+  }
+
+  category.items.push(item)
+  return item
+}
+
+export function findDataStructureItem(catalog, itemNameOrSlug) {
+  const itemSlug = slugify(itemNameOrSlug)
+
+  return getDataStructureItems(catalog).find((item) => item.slug === itemSlug) ?? null
+}
+
+export function ensureDataStructureItem(catalog, { title }) {
+  const existingItem = findDataStructureItem(catalog, title)
+
+  if (existingItem) {
+    return existingItem
+  }
+
+  const item = {
+    slug: slugify(title),
+    title,
+  }
+
+  getDataStructureItems(catalog).push(item)
+  return item
+}
+
+export function countCatalogItems(catalog, track) {
+  const normalizedTrack = normalizeTrackInput(track)
+
+  if (normalizedTrack === 'algorithms') {
+    return getAlgorithmCategories(catalog).reduce(
+      (total, category) => total + category.items.length,
+      0
+    )
+  }
+
+  return getDataStructureItems(catalog).length
+}

--- a/src/cli/colors.js
+++ b/src/cli/colors.js
@@ -1,0 +1,21 @@
+const palette = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+  red: '\x1b[31m',
+  magenta: '\x1b[35m',
+}
+
+export const COLORS = palette
+
+export function colorize(text, color, enabled = true) {
+  if (!enabled || !palette[color]) {
+    return text
+  }
+
+  return `${palette[color]}${text}${palette.reset}`
+}

--- a/src/cli/constants.js
+++ b/src/cli/constants.js
@@ -1,0 +1,64 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+function resolveOverride(envKey, fallbackPath) {
+  const value = process.env[envKey]
+
+  if (!value) {
+    return fallbackPath
+  }
+
+  return path.isAbsolute(value) ? value : path.resolve(process.cwd(), value)
+}
+
+export const PROJECT_ROOT = resolveOverride(
+  'DSA_CLI_ROOT',
+  path.resolve(__dirname, '../..')
+)
+
+export const ALGORITHMS_DIR = resolveOverride(
+  'DSA_CLI_ALGORITHMS_DIR',
+  path.join(PROJECT_ROOT, 'src', 'algorithms')
+)
+
+export const DATA_STRUCTURES_DIR = resolveOverride(
+  'DSA_CLI_DATA_STRUCTURES_DIR',
+  path.join(PROJECT_ROOT, 'src', 'data-structures')
+)
+
+export const README_PATH = resolveOverride(
+  'DSA_CLI_README_PATH',
+  path.join(PROJECT_ROOT, 'readme.md')
+)
+
+export const CATALOG_PATH = resolveOverride(
+  'DSA_CLI_CATALOG_PATH',
+  path.join(PROJECT_ROOT, 'src', 'cli', 'problem-catalog.json')
+)
+
+export const SCAFFOLD_MARKER = '@dsa-cli-status scaffold'
+export const DEFAULT_RECENT_LIMIT = 5
+export const DEFAULT_NEXT_LIMIT = 5
+
+export const IGNORED_DIRECTORY_NAMES = new Set([
+  '.git',
+  '.pytest_cache',
+  '.venv',
+  '__pycache__',
+  'node_modules',
+  'utils',
+  'venv',
+])
+
+export const TRACKS = [
+  { id: 'algorithms', title: 'Algorithms' },
+  { id: 'data-structures', title: 'Data Structures' },
+]
+
+export const LANGUAGES = [
+  { id: 'typescript', title: 'TypeScript' },
+  { id: 'python', title: 'Python' },
+]

--- a/src/cli/dashboard.js
+++ b/src/cli/dashboard.js
@@ -1,0 +1,179 @@
+import { colorize } from './colors.js'
+
+function createProgressBar(solved, scaffolded, total, useColor) {
+  const width = 16
+
+  if (total === 0) {
+    return colorize('░'.repeat(width), 'dim', useColor)
+  }
+
+  let solvedUnits = Math.round((solved / total) * width)
+  let scaffoldedUnits = Math.round((scaffolded / total) * width)
+
+  if (solvedUnits + scaffoldedUnits > width) {
+    const overflow = solvedUnits + scaffoldedUnits - width
+    scaffoldedUnits = Math.max(0, scaffoldedUnits - overflow)
+  }
+
+  const remainingUnits = Math.max(0, width - solvedUnits - scaffoldedUnits)
+
+  return [
+    colorize('█'.repeat(solvedUnits), 'green', useColor),
+    colorize('▒'.repeat(scaffoldedUnits), 'yellow', useColor),
+    colorize('░'.repeat(remainingUnits), 'dim', useColor),
+  ].join('')
+}
+
+function renderHeader(title, useColor) {
+  const line = '═'.repeat(60)
+  return [
+    colorize(`\n${line}`, 'cyan', useColor),
+    colorize(`  ${title}`, 'cyan', useColor),
+    colorize(line, 'cyan', useColor),
+    '',
+  ]
+}
+
+function renderSummary(title, summary, useColor) {
+  return [
+    colorize(title, 'bright', useColor),
+    colorize('─'.repeat(50), 'dim', useColor),
+    `  ${colorize('Solved'.padEnd(12), 'green', useColor)} ${summary.solved} / ${summary.total}`,
+    `  ${colorize('In progress'.padEnd(12), 'yellow', useColor)} ${summary.scaffolded}`,
+    `  ${colorize('Remaining'.padEnd(12), 'red', useColor)} ${summary.remaining}`,
+    '',
+  ]
+}
+
+function renderCategoryProgress(state, useColor) {
+  const lines = [
+    colorize('Algorithm Categories', 'bright', useColor),
+    colorize('─'.repeat(50), 'dim', useColor),
+  ]
+
+  for (const category of state.algorithms.categories) {
+    const { solved, scaffolded, remaining, total } = category.summary
+    const bar = createProgressBar(solved, scaffolded, total, useColor)
+
+    lines.push(
+      `  ${colorize(category.slug.padEnd(24), 'yellow', useColor)} ${String(solved).padStart(2)}/${String(total).padEnd(2)} solved ${bar}  ${scaffolded} active / ${remaining} left`
+    )
+  }
+
+  lines.push('')
+  return lines
+}
+
+function renderLanguageCoverage(state, useColor) {
+  const lines = [
+    colorize('Language Coverage', 'bright', useColor),
+    colorize('─'.repeat(50), 'dim', useColor),
+  ]
+
+  for (const language of state.languages) {
+    lines.push(
+      `  ${colorize(language.title.padEnd(12), 'blue', useColor)} solved ${String(language.solved).padStart(2)}  active ${String(language.scaffolded).padStart(2)}`
+    )
+  }
+
+  lines.push('')
+  return lines
+}
+
+function renderActivityItems(title, items, useColor) {
+  const lines = [
+    colorize(title, 'bright', useColor),
+    colorize('─'.repeat(50), 'dim', useColor),
+  ]
+
+  if (items.length === 0) {
+    lines.push(`  ${colorize('None yet', 'dim', useColor)}`)
+    lines.push('')
+    return lines
+  }
+
+  for (const item of items) {
+    const statusIcon =
+      item.status === 'solved'
+        ? colorize('✓', 'green', useColor)
+        : item.status === 'scaffolded'
+          ? colorize('●', 'yellow', useColor)
+          : colorize('○', 'dim', useColor)
+
+    const trackLabel = item.track === 'algorithms' ? 'Algorithms' : 'Data Structures'
+    const locationLabel = item.categoryTitle
+      ? `${trackLabel} / ${item.categoryTitle}`
+      : trackLabel
+    const languageLabel = item.implementations
+      .map((implementation) => implementation.language)
+      .join(', ') || 'none'
+
+    lines.push(
+      `  ${statusIcon} ${colorize(item.title, 'cyan', useColor)} ${colorize(`(${locationLabel})`, 'dim', useColor)} [${languageLabel}]`
+    )
+  }
+
+  lines.push('')
+  return lines
+}
+
+function renderDataStructures(state, useColor) {
+  const lines = [
+    colorize('Data Structures', 'bright', useColor),
+    colorize('─'.repeat(50), 'dim', useColor),
+  ]
+
+  for (const item of state.dataStructures.items) {
+    const statusColor = item.status === 'solved' ? 'green' : item.status === 'scaffolded' ? 'yellow' : 'red'
+    const languages = item.implementations.map((implementation) => implementation.language).join(', ') || 'none'
+
+    lines.push(
+      `  ${colorize(item.title.padEnd(24), statusColor, useColor)} ${item.status.padEnd(10)} [${languages}]`
+    )
+  }
+
+  lines.push('')
+  return lines
+}
+
+function renderCatalogNotes(state, useColor) {
+  const lines = [
+    colorize('Catalog Notes', 'bright', useColor),
+    colorize('─'.repeat(50), 'dim', useColor),
+  ]
+
+  if (state.discoveredItems.length === 0) {
+    lines.push(`  ${colorize('Catalog and filesystem are in sync.', 'green', useColor)}`)
+    lines.push('')
+    return lines
+  }
+
+  lines.push(
+    `  ${colorize(`${state.discoveredItems.length} discovered implementation(s) are not tracked in the catalog yet.`, 'yellow', useColor)}`
+  )
+
+  for (const item of state.discoveredItems.slice(0, 5)) {
+    lines.push(`  - ${item.title} (${item.track})`)
+  }
+
+  lines.push('')
+  return lines
+}
+
+export function renderDashboard(state, { useColor = true } = {}) {
+  const lines = []
+
+  lines.push(...renderHeader('DSA Workspace Dashboard', useColor))
+  lines.push(...renderSummary('Overall', state.overall, useColor))
+  lines.push(...renderSummary('Algorithms', state.algorithms, useColor))
+  lines.push(...renderCategoryProgress(state, useColor))
+  lines.push(...renderSummary('Data Structure Totals', state.dataStructures, useColor))
+  lines.push(...renderDataStructures(state, useColor))
+  lines.push(...renderLanguageCoverage(state, useColor))
+  lines.push(...renderActivityItems('In Progress', state.activeItems, useColor))
+  lines.push(...renderActivityItems('Next Up', state.nextItems, useColor))
+  lines.push(...renderActivityItems('Recent Activity', state.recentActivity, useColor))
+  lines.push(...renderCatalogNotes(state, useColor))
+
+  return lines.join('\n').trimEnd()
+}

--- a/src/cli/generate.js
+++ b/src/cli/generate.js
@@ -1,0 +1,427 @@
+import fs from 'fs'
+import path from 'path'
+
+import {
+  ALGORITHMS_DIR,
+  DATA_STRUCTURES_DIR,
+  LANGUAGES,
+  PROJECT_ROOT,
+  SCAFFOLD_MARKER,
+  TRACKS,
+} from './constants.js'
+import {
+  ensureAlgorithmItem,
+  ensureDataStructureItem,
+  findAlgorithmCategory,
+  findAlgorithmItem,
+  findDataStructureItem,
+  saveCatalog,
+} from './catalog.js'
+import {
+  getPythonModuleName,
+  normalizeCategoryInput,
+  normalizeLanguageInput,
+  normalizeTrackInput,
+  slugify,
+  titleFromSlug,
+} from './normalize.js'
+import { createPrompter } from './prompts.js'
+import { buildTemplateSet } from './templates.js'
+
+function formatDisplayStatus(item) {
+  if (item.status === 'solved') {
+    return 'solved'
+  }
+
+  if (item.status === 'scaffolded') {
+    return 'in progress'
+  }
+
+  return 'remaining'
+}
+
+function buildSolutionPaths(request) {
+  if (request.track === 'algorithms') {
+    const problemDirectoryPath = path.join(
+      ALGORITHMS_DIR,
+      request.categorySlug,
+      request.itemSlug
+    )
+
+    if (request.language === 'typescript') {
+      return {
+        problemDirectoryPath,
+        solutionPath: path.join(problemDirectoryPath, `${request.itemSlug}.ts`),
+        testPath: path.join(problemDirectoryPath, `${request.itemSlug}.spec.ts`),
+      }
+    }
+
+    const pythonModuleName = getPythonModuleName(request.itemSlug)
+
+    return {
+      problemDirectoryPath,
+      solutionPath: path.join(problemDirectoryPath, `${pythonModuleName}.py`),
+      testPath: path.join(problemDirectoryPath, `test_${pythonModuleName}.py`),
+    }
+  }
+
+  const structureDirectoryPath = path.join(DATA_STRUCTURES_DIR, request.itemSlug)
+
+  if (request.language === 'typescript') {
+    return {
+      problemDirectoryPath: structureDirectoryPath,
+      solutionPath: path.join(structureDirectoryPath, `${request.itemSlug}.ts`),
+      testPath: path.join(
+        structureDirectoryPath,
+        '__tests__',
+        `${request.itemSlug}.spec.ts`
+      ),
+    }
+  }
+
+  const pythonModuleName = getPythonModuleName(request.itemSlug)
+
+  return {
+    problemDirectoryPath: structureDirectoryPath,
+    solutionPath: path.join(structureDirectoryPath, `${pythonModuleName}.py`),
+    testPath: path.join(structureDirectoryPath, `test_${pythonModuleName}.py`),
+  }
+}
+
+function renderGenerationSummary(result) {
+  const lines = [
+    'Scaffold created successfully.',
+    `- Solution: ${result.solutionPath}`,
+    `- Test: ${result.testPath}`,
+  ]
+
+  if (result.createdCatalogEntry) {
+    lines.push('- Catalog: added a new tracked item to src/cli/problem-catalog.json')
+  }
+
+  lines.push(
+    `- Next step: remove the ${SCAFFOLD_MARKER} marker once the implementation is complete so the dashboard counts it as solved.`
+  )
+
+  return lines.join('\n')
+}
+
+function resolveAlgorithmSelectionByFlag(state, categorySlug, problemNameOrSlug) {
+  const normalizedCategorySlug = normalizeCategoryInput(categorySlug)
+  const category = state.algorithms.categories.find(
+    (candidate) => candidate.slug === normalizedCategorySlug
+  )
+
+  if (!category) {
+    return {
+      categorySlug: normalizedCategorySlug,
+      categoryTitle: titleFromSlug(normalizedCategorySlug),
+      item: null,
+    }
+  }
+
+  const itemSlug = slugify(problemNameOrSlug)
+  const item = category.items.find((candidate) => candidate.slug === itemSlug) ?? null
+
+  return {
+    categorySlug: category.slug,
+    categoryTitle: category.title,
+    item,
+  }
+}
+
+async function resolveAlgorithmRequest({ flags, state, prompter }) {
+  let categorySlug = normalizeCategoryInput(flags.category)
+  let categoryTitle = categorySlug ? titleFromSlug(categorySlug) : null
+
+  if (!categorySlug) {
+    const selectedCategory = await prompter.select(
+      'Choose an algorithm category',
+      [
+        ...state.algorithms.categories.map((category) => ({
+          label: `${category.title} (${category.summary.solved}/${category.summary.total} solved)`,
+          value: { type: 'existing', category },
+        })),
+        {
+          label: 'Create a custom category',
+          value: { type: 'custom' },
+        },
+      ]
+    )
+
+    if (selectedCategory.type === 'custom') {
+      categoryTitle = await prompter.ask('Category name')
+      categorySlug = normalizeCategoryInput(categoryTitle)
+
+      if (!categorySlug || !categoryTitle.trim()) {
+        throw new Error('A non-empty category name is required.')
+      }
+    } else {
+      categoryTitle = selectedCategory.category.title
+      categorySlug = selectedCategory.category.slug
+    }
+  } else {
+    const existingCategory = state.algorithms.categories.find(
+      (candidate) => candidate.slug === categorySlug
+    )
+
+    if (existingCategory) {
+      categoryTitle = existingCategory.title
+    }
+  }
+
+  let selectedItem = null
+  let itemTitle = flags.problem || flags.name || ''
+
+  if (itemTitle) {
+    const selection = resolveAlgorithmSelectionByFlag(state, categorySlug, itemTitle)
+    categoryTitle = selection.categoryTitle
+    selectedItem = selection.item
+  } else {
+    const category = state.algorithms.categories.find(
+      (candidate) => candidate.slug === categorySlug
+    )
+
+    const selection = await prompter.select(
+      `Choose a problem from ${categoryTitle}`,
+      [
+        ...(category?.items ?? []).map((item) => ({
+          label: `${item.title} (${formatDisplayStatus(item)})`,
+          value: { type: 'existing', item },
+        })),
+        {
+          label: 'Create a custom problem',
+          value: { type: 'custom' },
+        },
+      ]
+    )
+
+    if (selection.type === 'custom') {
+      itemTitle = await prompter.ask('Problem name')
+    } else {
+      selectedItem = selection.item
+      itemTitle = selectedItem.title
+    }
+  }
+
+  return {
+    categorySlug,
+    categoryTitle,
+    itemTitle: selectedItem?.title ?? itemTitle,
+    selectedItem,
+  }
+}
+
+async function resolveDataStructureRequest({ flags, state, prompter }) {
+  let selectedItem = null
+  let itemTitle = flags.problem || flags.name || ''
+
+  if (itemTitle) {
+    selectedItem =
+      state.dataStructures.items.find(
+        (candidate) => candidate.slug === slugify(itemTitle)
+      ) ?? null
+  } else {
+    const selection = await prompter.select('Choose a data structure', [
+      ...state.dataStructures.items.map((item) => ({
+        label: `${item.title} (${formatDisplayStatus(item)})`,
+        value: { type: 'existing', item },
+      })),
+      {
+        label: 'Create a custom data structure',
+        value: { type: 'custom' },
+      },
+    ])
+
+    if (selection.type === 'custom') {
+      itemTitle = await prompter.ask('Data structure name')
+    } else {
+      selectedItem = selection.item
+      itemTitle = selectedItem.title
+    }
+  }
+
+  return {
+    itemTitle: selectedItem?.title ?? itemTitle,
+    selectedItem,
+  }
+}
+
+async function resolveLanguage(flags, prompter) {
+  const normalizedLanguage = normalizeLanguageInput(flags.language)
+
+  if (normalizedLanguage) {
+    return normalizedLanguage
+  }
+
+  return prompter.select(
+    'Choose a language',
+    LANGUAGES.map((language) => ({
+      label: language.title,
+      value: language.id,
+    }))
+  )
+}
+
+export async function runGenerateCommand({ parsed, io, snapshot, prompter }) {
+  const track = normalizeTrackInput(parsed.flags.track)
+  const missingCategory =
+    track === 'algorithms' && !normalizeCategoryInput(parsed.flags.category)
+  const needsPrompting =
+    !track ||
+    !normalizeLanguageInput(parsed.flags.language) ||
+    (!parsed.flags.problem && !parsed.flags.name) ||
+    missingCategory
+
+  let activePrompter = prompter
+  let ownsPrompter = false
+
+  if (!activePrompter && needsPrompting) {
+    if (!io.input.isTTY && needsPrompting) {
+      throw new Error(
+        'Missing required generation flags. Provide --track, --language, and --problem (plus --category for algorithms), or run the CLI interactively.'
+      )
+    }
+
+    activePrompter = createPrompter({ input: io.input, output: io.output })
+    ownsPrompter = true
+  }
+
+  try {
+    const resolvedTrack =
+      track ??
+      (await activePrompter.select(
+        'Choose a track',
+        TRACKS.map((option) => ({
+          label: option.title,
+          value: option.id,
+        }))
+      ))
+
+    let request
+
+    if (resolvedTrack === 'algorithms') {
+      const algorithmRequest = await resolveAlgorithmRequest({
+        flags: parsed.flags,
+        state: snapshot.state,
+        prompter: activePrompter,
+      })
+
+      request = {
+        track: 'algorithms',
+        categorySlug: algorithmRequest.categorySlug,
+        categoryTitle: algorithmRequest.categoryTitle,
+        itemTitle: algorithmRequest.itemTitle,
+        itemSlug: slugify(algorithmRequest.itemTitle),
+        language: await resolveLanguage(parsed.flags, activePrompter),
+      }
+    } else {
+      const dataStructureRequest = await resolveDataStructureRequest({
+        flags: parsed.flags,
+        state: snapshot.state,
+        prompter: activePrompter,
+      })
+
+      request = {
+        track: 'data-structures',
+        itemTitle: dataStructureRequest.itemTitle,
+        itemSlug: slugify(dataStructureRequest.itemTitle),
+        language: await resolveLanguage(parsed.flags, activePrompter),
+      }
+    }
+
+    if (!request.itemSlug) {
+      throw new Error('A problem or data-structure name is required to generate a scaffold.')
+    }
+
+    if (typeof request.itemTitle !== 'string' || request.itemTitle.trim().length === 0) {
+      throw new Error('A non-empty problem or data-structure name is required.')
+    }
+
+    const paths = buildSolutionPaths(request)
+
+    if (fs.existsSync(paths.solutionPath) || fs.existsSync(paths.testPath)) {
+      throw new Error(
+        `A ${request.language} scaffold already exists for ${request.itemTitle}. Refusing to overwrite existing work.`
+      )
+    }
+
+    const templates = buildTemplateSet(request)
+    const createdDirectories = [
+      paths.problemDirectoryPath,
+      path.dirname(paths.testPath),
+    ]
+    const createdFiles = []
+    const nextCatalog = JSON.parse(JSON.stringify(snapshot.catalog))
+    let createdCatalogEntry = false
+
+    try {
+      fs.mkdirSync(paths.problemDirectoryPath, { recursive: true })
+      fs.mkdirSync(path.dirname(paths.testPath), { recursive: true })
+
+      fs.writeFileSync(paths.solutionPath, templates.solution)
+      createdFiles.push(paths.solutionPath)
+
+      fs.writeFileSync(paths.testPath, templates.test)
+      createdFiles.push(paths.testPath)
+
+      if (request.track === 'algorithms') {
+        const category = findAlgorithmCategory(nextCatalog, request.categorySlug)
+        const existingItem = findAlgorithmItem(
+          nextCatalog,
+          request.categorySlug,
+          request.itemSlug
+        )
+
+        if (!category || !existingItem) {
+          createdCatalogEntry = true
+        }
+
+        ensureAlgorithmItem(nextCatalog, {
+          categorySlug: request.categorySlug,
+          categoryTitle: request.categoryTitle,
+          title: request.itemTitle,
+          tags: [request.categoryTitle],
+        })
+      } else {
+        const existingItem = findDataStructureItem(nextCatalog, request.itemSlug)
+
+        if (!existingItem) {
+          createdCatalogEntry = true
+        }
+
+        ensureDataStructureItem(nextCatalog, {
+          title: request.itemTitle,
+        })
+      }
+
+      saveCatalog(nextCatalog)
+    } catch (error) {
+      createdFiles.reverse().forEach((filePath) => {
+        if (fs.existsSync(filePath)) {
+          fs.rmSync(filePath, { force: true })
+        }
+      })
+
+      createdDirectories.reverse().forEach((directoryPath) => {
+        if (fs.existsSync(directoryPath) && fs.readdirSync(directoryPath).length === 0) {
+          fs.rmdirSync(directoryPath)
+        }
+      })
+
+      throw error
+    }
+
+    return {
+      message: renderGenerationSummary({
+        solutionPath: path.relative(PROJECT_ROOT, paths.solutionPath),
+        testPath: path.relative(PROJECT_ROOT, paths.testPath),
+        createdCatalogEntry,
+      }),
+    }
+  } finally {
+    if (ownsPrompter) {
+      activePrompter.close()
+    }
+  }
+}

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,0 +1,174 @@
+import { loadCatalog } from './catalog.js'
+import { renderDashboard } from './dashboard.js'
+import { runGenerateCommand } from './generate.js'
+import { createPrompter } from './prompts.js'
+import { scanRepository } from './scanner.js'
+import { buildProjectState } from './state.js'
+
+function parseArguments(argv) {
+  const flags = {}
+  const positionals = []
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+
+    if (argument === '--') {
+      positionals.push(...argv.slice(index + 1))
+      break
+    }
+
+    if (argument.startsWith('--')) {
+      const [rawFlag, inlineValue] = argument.slice(2).split('=', 2)
+
+      if (inlineValue !== undefined) {
+        flags[rawFlag] = inlineValue
+        continue
+      }
+
+      const nextArgument = argv[index + 1]
+
+      if (nextArgument !== undefined && !nextArgument.startsWith('-')) {
+        flags[rawFlag] = nextArgument
+        index += 1
+        continue
+      }
+
+      flags[rawFlag] = true
+      continue
+    }
+
+    if (argument.startsWith('-') && argument.length > 1) {
+      for (const shortFlag of argument.slice(1)) {
+        if (shortFlag === 'h') {
+          flags.help = true
+        }
+
+        if (shortFlag === 'j') {
+          flags.json = true
+        }
+      }
+
+      continue
+    }
+
+    positionals.push(argument)
+  }
+
+  return {
+    command: positionals[0] ?? null,
+    positionals: positionals.slice(1),
+    flags,
+  }
+}
+
+function useColor(output, flags) {
+  return output.isTTY && !flags['no-color']
+}
+
+function loadSnapshot() {
+  const catalog = loadCatalog()
+  const scanResults = scanRepository()
+  const state = buildProjectState(catalog, scanResults)
+
+  return {
+    catalog,
+    scanResults,
+    state,
+  }
+}
+
+function renderHelp() {
+  return `DSA CLI\n\nUsage:\n  dsa [command] [options]\n  node cli.js [command] [options]\n\nCommands:\n  dashboard, status         Show solved, in-progress, and remaining work\n  generate, new            Create starter files for an algorithm or data structure\n  help                     Show this help message\n\nDashboard options:\n  --json                   Print the dashboard data as JSON\n  --no-color               Disable ANSI colors\n\nGenerate options:\n  --track <algorithms|data-structures>\n  --category <slug>        Required for algorithm generation\n  --problem <name>         Problem or data-structure name\n  --language <typescript|python>\n\nExamples:\n  npm run cli -- dashboard\n  npm run cli -- generate --track algorithms --category arrays --problem "Common Child" --language typescript\n  npm run cli -- generate --track data-structures --problem "binary-tree" --language python\n`
+}
+
+async function runInteractive(io) {
+  if (!io.input.isTTY) {
+    io.output.write(`${renderHelp()}\n`)
+    return 0
+  }
+
+  const prompter = createPrompter({ input: io.input, output: io.output })
+
+  try {
+    while (true) {
+      const selectedAction = await prompter.select('What would you like to do?', [
+        { label: 'View the dashboard', value: 'dashboard' },
+        { label: 'Generate a new scaffold', value: 'generate' },
+        { label: 'Exit', value: 'exit' },
+      ])
+
+      if (selectedAction === 'exit') {
+        break
+      }
+
+      if (selectedAction === 'dashboard') {
+        const snapshot = loadSnapshot()
+        io.output.write(`\n${renderDashboard(snapshot.state, { useColor: useColor(io.output, {}) })}\n\n`)
+        continue
+      }
+
+      const snapshot = loadSnapshot()
+      const result = await runGenerateCommand({
+        parsed: { command: 'generate', positionals: [], flags: {} },
+        io,
+        snapshot,
+        prompter,
+      })
+
+      io.output.write(`\n${result.message}\n\n`)
+    }
+  } finally {
+    prompter.close()
+  }
+
+  return 0
+}
+
+export async function runCli(argv = process.argv.slice(2), io = {}) {
+  const resolvedIo = {
+    input: io.input ?? process.stdin,
+    output: io.output ?? process.stdout,
+    error: io.error ?? process.stderr,
+  }
+
+  const parsed = parseArguments(argv)
+
+  if (parsed.flags.help || ['help', '--help'].includes(parsed.command)) {
+    resolvedIo.output.write(`${renderHelp()}\n`)
+    return 0
+  }
+
+  if (!parsed.command) {
+    return runInteractive(resolvedIo)
+  }
+
+  if (['dashboard', 'status'].includes(parsed.command)) {
+    const snapshot = loadSnapshot()
+
+    if (parsed.flags.json) {
+      resolvedIo.output.write(`${JSON.stringify(snapshot.state, null, 2)}\n`)
+      return 0
+    }
+
+    resolvedIo.output.write(
+      `${renderDashboard(snapshot.state, {
+        useColor: useColor(resolvedIo.output, parsed.flags),
+      })}\n`
+    )
+    return 0
+  }
+
+  if (['generate', 'new'].includes(parsed.command)) {
+    const snapshot = loadSnapshot()
+    const result = await runGenerateCommand({
+      parsed,
+      io: resolvedIo,
+      snapshot,
+    })
+
+    resolvedIo.output.write(`${result.message}\n`)
+    return 0
+  }
+
+  throw new Error(`Unknown command: ${parsed.command}`)
+}

--- a/src/cli/normalize.js
+++ b/src/cli/normalize.js
@@ -1,0 +1,165 @@
+const TRACK_ALIASES = new Map([
+  ['algo', 'algorithms'],
+  ['algorithm', 'algorithms'],
+  ['algorithms', 'algorithms'],
+  ['data-structure', 'data-structures'],
+  ['data-structures', 'data-structures'],
+  ['datastructure', 'data-structures'],
+  ['datastructures', 'data-structures'],
+  ['ds', 'data-structures'],
+  ['structure', 'data-structures'],
+  ['structures', 'data-structures'],
+])
+
+const LANGUAGE_ALIASES = new Map([
+  ['py', 'python'],
+  ['python', 'python'],
+  ['ts', 'typescript'],
+  ['typescript', 'typescript'],
+])
+
+const CATEGORY_ALIASES = new Map([
+  ['arrays-hash-tables', 'arrays_hashtables'],
+  ['arrays-hashtables', 'arrays_hashtables'],
+  ['arrays-plus-hash-tables', 'arrays_hashtables'],
+  ['backtracking', 'backtracking'],
+])
+
+export function slugify(value) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[’']/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function normalizeTrackInput(value) {
+  if (!value) {
+    return null
+  }
+
+  const normalized = slugify(value)
+  return TRACK_ALIASES.get(normalized) ?? null
+}
+
+export function normalizeLanguageInput(value) {
+  if (!value) {
+    return null
+  }
+
+  const normalized = slugify(value)
+  return LANGUAGE_ALIASES.get(normalized) ?? null
+}
+
+export function normalizeCategoryInput(value) {
+  if (!value) {
+    return null
+  }
+
+  const normalized = slugify(value)
+  return CATEGORY_ALIASES.get(normalized) ?? normalized
+}
+
+export function toSnakeCase(value) {
+  return slugify(value).replace(/-/g, '_')
+}
+
+export function getPythonModuleName(value) {
+  const snakeCase = toSnakeCase(value)
+
+  if (/^\d/.test(snakeCase)) {
+    return `problem_${snakeCase}`
+  }
+
+  return snakeCase
+}
+
+export function toCamelCase(value) {
+  const words = slugify(value)
+    .split('-')
+    .filter(Boolean)
+
+  return words
+    .map((word, index) => {
+      if (index === 0) {
+        return word
+      }
+
+      return `${word.charAt(0).toUpperCase()}${word.slice(1)}`
+    })
+    .join('')
+}
+
+export function toPascalCase(value) {
+  const camelCase = toCamelCase(value)
+
+  if (!camelCase) {
+    return ''
+  }
+
+  return `${camelCase.charAt(0).toUpperCase()}${camelCase.slice(1)}`
+}
+
+export function toFunctionName(value) {
+  const camelCase = toCamelCase(value)
+
+  if (!camelCase) {
+    return 'solveProblem'
+  }
+
+  if (/^\d/.test(camelCase)) {
+    return `solve${camelCase.charAt(0).toUpperCase()}${camelCase.slice(1)}`
+  }
+
+  return camelCase
+}
+
+export function toClassName(value) {
+  const pascalCase = toPascalCase(value)
+
+  if (!pascalCase) {
+    return 'DataStructure'
+  }
+
+  if (/^\d/.test(pascalCase)) {
+    return `DataStructure${pascalCase}`
+  }
+
+  return pascalCase
+}
+
+export function toPythonFunctionName(value) {
+  const snakeCase = toSnakeCase(value)
+
+  if (!snakeCase) {
+    return 'solve_problem'
+  }
+
+  if (/^\d/.test(snakeCase)) {
+    return `solve_${snakeCase}`
+  }
+
+  return snakeCase
+}
+
+export function titleFromSlug(value) {
+  return String(value ?? '')
+    .replace(/[_-]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => {
+      if (!word) {
+        return word
+      }
+
+      if (/^\d/.test(word)) {
+        return word.toUpperCase()
+      }
+
+      return `${word.charAt(0).toUpperCase()}${word.slice(1)}`
+    })
+    .join(' ')
+}

--- a/src/cli/problem-catalog.json
+++ b/src/cli/problem-catalog.json
@@ -1,0 +1,1361 @@
+{
+  "version": 1,
+  "updatedAt": "2026-03-07T09:16:25.782Z",
+  "tracks": {
+    "algorithms": {
+      "title": "Algorithms",
+      "categories": [
+        {
+          "slug": "arrays",
+          "title": "Arrays",
+          "items": [
+            {
+              "slug": "max-value",
+              "title": "Max value",
+              "tags": [
+                "Arrays"
+              ]
+            },
+            {
+              "slug": "is-monotonic",
+              "title": "Is-Monotonic",
+              "tags": [
+                "Arrays"
+              ]
+            },
+            {
+              "slug": "2d-array-ds",
+              "title": "2D Array - DS",
+              "tags": [
+                "Arrays"
+              ]
+            },
+            {
+              "slug": "left-rotation",
+              "title": "Left Rotation",
+              "tags": [
+                "Arrays"
+              ]
+            },
+            {
+              "slug": "new-year-chaos",
+              "title": "New Year Chaos",
+              "tags": [
+                "Arrays"
+              ]
+            },
+            {
+              "slug": "minimum-swaps-2",
+              "title": "Minimum Swaps 2",
+              "tags": [
+                "Arrays"
+              ]
+            },
+            {
+              "slug": "array-manipulation",
+              "title": "Array Manipulation",
+              "tags": [
+                "Arrays"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "hashtables",
+          "title": "Hash Tables",
+          "items": [
+            {
+              "slug": "ransom-note",
+              "title": "Ransom Note",
+              "tags": [
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "two-strings",
+              "title": "Two Strings",
+              "tags": [
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "sherlock-and-anagrams",
+              "title": "Sherlock and Anagrams",
+              "tags": [
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "count-triplets",
+              "title": "Count Triplets",
+              "tags": [
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "frequency-queries",
+              "title": "Frequency Queries",
+              "tags": [
+                "Hash Tables"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "strings",
+          "title": "Strings",
+          "items": [
+            {
+              "slug": "make-anagram",
+              "title": "Making Anagrams",
+              "tags": [
+                "Strings"
+              ]
+            },
+            {
+              "slug": "alternating-characters",
+              "title": "Alternating Characters",
+              "tags": [
+                "Strings"
+              ]
+            },
+            {
+              "slug": "sherlock-and-the-valid-string",
+              "title": "Sherlock and the Valid String",
+              "tags": [
+                "Strings"
+              ]
+            },
+            {
+              "slug": "special-string-again",
+              "title": "Special String Again",
+              "tags": [
+                "Strings"
+              ]
+            },
+            {
+              "slug": "common-child",
+              "title": "Common Child",
+              "tags": [
+                "Strings"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "arrays_hashtables",
+          "title": "Arrays + Hash Tables",
+          "items": [
+            {
+              "slug": "contains-duplicate",
+              "title": "Contains-Duplicate",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "valid-anagram",
+              "title": "Valid Anagram",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "two-sum",
+              "title": "Two Sum",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "group-anagrams",
+              "title": "Group Anagrams",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "top-k-frequent-elements",
+              "title": "Top K Frequent Elements",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "product-of-array-except-self",
+              "title": "Product of Array Except Self",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "valid-sudoku",
+              "title": "Valid Sudoku",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "encode-and-decode-strings",
+              "title": "Encode and Decode Strings",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            },
+            {
+              "slug": "longest-consecutive-sequence",
+              "title": "Longest Consecutive Sequence",
+              "tags": [
+                "Arrays",
+                "Hash Tables"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "two-pointers",
+          "title": "Two Pointers",
+          "items": [
+            {
+              "slug": "valid-palindrome",
+              "title": "Valid Palindrome",
+              "tags": [
+                "Two Pointers"
+              ]
+            },
+            {
+              "slug": "two-sum-ii-input-array-is-sorted",
+              "title": "Two Sum II Input Array Is Sorted",
+              "tags": [
+                "Two Pointers"
+              ]
+            },
+            {
+              "slug": "3sum",
+              "title": "3Sum",
+              "tags": [
+                "Two Pointers"
+              ]
+            },
+            {
+              "slug": "container-with-most-water",
+              "title": "Container With Most Water",
+              "tags": [
+                "Two Pointers"
+              ]
+            },
+            {
+              "slug": "trapping-rain-water",
+              "title": "Trapping Rain Water",
+              "tags": [
+                "Two Pointers"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "stack",
+          "title": "Stack",
+          "items": [
+            {
+              "slug": "valid-parentheses",
+              "title": "Valid Parentheses",
+              "tags": [
+                "Stack"
+              ]
+            },
+            {
+              "slug": "min-stack",
+              "title": "Min Stack",
+              "tags": [
+                "Stack"
+              ]
+            },
+            {
+              "slug": "evaluate-reverse-polish-notation",
+              "title": "Evaluate Reverse Polish Notation",
+              "tags": [
+                "Stack"
+              ]
+            },
+            {
+              "slug": "generate-parentheses",
+              "title": "Generate Parentheses",
+              "tags": [
+                "Stack"
+              ]
+            },
+            {
+              "slug": "daily-temperatures",
+              "title": "Daily Temperatures",
+              "tags": [
+                "Stack"
+              ]
+            },
+            {
+              "slug": "car-fleet",
+              "title": "Car Fleet",
+              "tags": [
+                "Stack"
+              ]
+            },
+            {
+              "slug": "largest-rectangle-in-histogram",
+              "title": "Largest Rectangle In Histogram",
+              "tags": [
+                "Stack"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "binary-search",
+          "title": "Binary Search",
+          "items": [
+            {
+              "slug": "binary-search",
+              "title": "Binary Search",
+              "tags": [
+                "Binary Search"
+              ]
+            },
+            {
+              "slug": "search-a-2d-matrix",
+              "title": "Search a 2D Matrix",
+              "tags": [
+                "Binary Search"
+              ]
+            },
+            {
+              "slug": "koko-eating-bananas",
+              "title": "Koko Eating Bananas",
+              "tags": [
+                "Binary Search"
+              ]
+            },
+            {
+              "slug": "find-minimum-in-rotated-sorted-array",
+              "title": "Find Minimum In Rotated Sorted Array",
+              "tags": [
+                "Binary Search"
+              ]
+            },
+            {
+              "slug": "search-in-rotated-sorted-array",
+              "title": "Search In Rotated Sorted Array",
+              "tags": [
+                "Binary Search"
+              ]
+            },
+            {
+              "slug": "time-based-key-value-store",
+              "title": "Time Based Key Value Store",
+              "tags": [
+                "Binary Search"
+              ]
+            },
+            {
+              "slug": "median-of-two-sorted-arrays",
+              "title": "Median of Two Sorted Arrays",
+              "tags": [
+                "Binary Search"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "sliding-window",
+          "title": "Sliding Window",
+          "items": [
+            {
+              "slug": "best-time-to-buy-and-sell-stock",
+              "title": "Best Time to Buy And Sell Stock",
+              "tags": [
+                "Sliding Window"
+              ]
+            },
+            {
+              "slug": "longest-substring-without-repeating-characters",
+              "title": "Longest Substring Without Repeating Characters",
+              "tags": [
+                "Sliding Window"
+              ]
+            },
+            {
+              "slug": "longest-repeating-character-replacement",
+              "title": "Longest Repeating Character Replacement",
+              "tags": [
+                "Sliding Window"
+              ]
+            },
+            {
+              "slug": "permutation-in-string",
+              "title": "Permutation In String",
+              "tags": [
+                "Sliding Window"
+              ]
+            },
+            {
+              "slug": "minimum-window-substring",
+              "title": "Minimum Window Substring",
+              "tags": [
+                "Sliding Window"
+              ]
+            },
+            {
+              "slug": "sliding-window-maximum",
+              "title": "Sliding Window Maximum",
+              "tags": [
+                "Sliding Window"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "linked-list",
+          "title": "Linked List",
+          "items": [
+            {
+              "slug": "reverse-linked-list",
+              "title": "Reverse Linked List",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "merge-two-sorted-lists",
+              "title": "Merge Two Sorted Lists",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "reorder-list",
+              "title": "Reorder List",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "remove-nth-node-from-end-of-list",
+              "title": "Remove Nth Node From End of List",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "copy-list-with-random-pointer",
+              "title": "Copy List With Random Pointer",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "add-two-numbers",
+              "title": "Add Two Numbers",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "linked-list-cycle",
+              "title": "Linked List Cycle",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "find-the-duplicate-number",
+              "title": "Find The Duplicate Number",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "lru-cache",
+              "title": "LRU Cache",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "merge-k-sorted-lists",
+              "title": "Merge K Sorted Lists",
+              "tags": [
+                "Linked List"
+              ]
+            },
+            {
+              "slug": "reverse-nodes-in-k-group",
+              "title": "Reverse Nodes In K Group",
+              "tags": [
+                "Linked List"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "trees",
+          "title": "Trees",
+          "items": [
+            {
+              "slug": "invert-binary-tree",
+              "title": "Invert Binary Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "maximum-depth-of-binary-tree",
+              "title": "Maximum Depth of Binary Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "diameter-of-binary-tree",
+              "title": "Diameter of Binary Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "balanced-binary-tree",
+              "title": "Balanced Binary Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "same-tree",
+              "title": "Same Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "subtree-of-another-tree",
+              "title": "Subtree of Another Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "lowest-common-ancestor-of-a-binary-search-tree",
+              "title": "Lowest Common Ancestor of a Binary Search Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "binary-tree-level-order-traversal",
+              "title": "Binary Tree Level Order Traversal",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "binary-tree-right-side-view",
+              "title": "Binary Tree Right Side View",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "count-good-nodes-in-binary-tree",
+              "title": "Count Good Nodes In Binary Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "validate-binary-search-tree",
+              "title": "Validate Binary Search Tree",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "kth-smallest-element-in-a-bst",
+              "title": "Kth Smallest Element In a Bst",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "construct-binary-tree-from-preorder-and-inorder-traversal",
+              "title": "Construct Binary Tree From Preorder And Inorder Traversal",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "binary-tree-maximum-path-sum",
+              "title": "Binary Tree Maximum Path Sum",
+              "tags": [
+                "Trees"
+              ]
+            },
+            {
+              "slug": "serialize-and-deserialize-binary-tree",
+              "title": "Serialize And Deserialize Binary Tree",
+              "tags": [
+                "Trees"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "tries",
+          "title": "Tries",
+          "items": [
+            {
+              "slug": "implement-trie-prefix-tree",
+              "title": "Implement Trie Prefix Tree",
+              "tags": [
+                "Tries"
+              ]
+            },
+            {
+              "slug": "design-add-and-search-words-data-structure",
+              "title": "Design Add And Search Words Data Structure",
+              "tags": [
+                "Tries"
+              ]
+            },
+            {
+              "slug": "word-search-ii",
+              "title": "Word Search II",
+              "tags": [
+                "Tries"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "heap-priority-queue",
+          "title": "Heap / Priority Queue",
+          "items": [
+            {
+              "slug": "kth-largest-element-in-a-stream",
+              "title": "Kth Largest Element In a Stream",
+              "tags": [
+                "Heap / Priority Queue"
+              ]
+            },
+            {
+              "slug": "last-stone-weight",
+              "title": "Last Stone Weight",
+              "tags": [
+                "Heap / Priority Queue"
+              ]
+            },
+            {
+              "slug": "k-closest-points-to-origin",
+              "title": "K Closest Points to Origin",
+              "tags": [
+                "Heap / Priority Queue"
+              ]
+            },
+            {
+              "slug": "kth-largest-element-in-an-array",
+              "title": "Kth Largest Element In An Array",
+              "tags": [
+                "Heap / Priority Queue"
+              ]
+            },
+            {
+              "slug": "task-scheduler",
+              "title": "Task Scheduler",
+              "tags": [
+                "Heap / Priority Queue"
+              ]
+            },
+            {
+              "slug": "design-twitter",
+              "title": "Design Twitter",
+              "tags": [
+                "Heap / Priority Queue"
+              ]
+            },
+            {
+              "slug": "find-median-from-data-stream",
+              "title": "Find Median From Data Stream",
+              "tags": [
+                "Heap / Priority Queue"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "backtracking",
+          "title": "Backtracking",
+          "items": [
+            {
+              "slug": "subsets",
+              "title": "Subsets",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "combination-sum",
+              "title": "Combination Sum",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "permutations",
+              "title": "Permutations",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "subsets-ii",
+              "title": "Subsets II",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "combination-sum-ii",
+              "title": "Combination Sum II",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "word-search",
+              "title": "Word Search",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "palindrome-partitioning",
+              "title": "Palindrome Partitioning",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "letter-combinations-of-a-phone-number",
+              "title": "Letter Combinations of a Phone Number",
+              "tags": [
+                "Baktracking"
+              ]
+            },
+            {
+              "slug": "n-queens",
+              "title": "N Queens",
+              "tags": [
+                "Baktracking"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "intervals",
+          "title": "Intervals",
+          "items": [
+            {
+              "slug": "insert-interval",
+              "title": "Insert Interval",
+              "tags": [
+                "Intervals"
+              ]
+            },
+            {
+              "slug": "merge-intervals",
+              "title": "Merge Intervals",
+              "tags": [
+                "Intervals"
+              ]
+            },
+            {
+              "slug": "non-overlapping-intervals",
+              "title": "Non Overlapping Intervals",
+              "tags": [
+                "Intervals"
+              ]
+            },
+            {
+              "slug": "meeting-rooms",
+              "title": "Meeting Rooms",
+              "tags": [
+                "Intervals"
+              ]
+            },
+            {
+              "slug": "meeting-rooms-ii",
+              "title": "Meeting Rooms II",
+              "tags": [
+                "Intervals"
+              ]
+            },
+            {
+              "slug": "minimum-interval-to-include-each-query",
+              "title": "Minimum Interval to Include Each Query",
+              "tags": [
+                "Intervals"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "greedy",
+          "title": "Greedy",
+          "items": [
+            {
+              "slug": "maximum-subarray",
+              "title": "Maximum Subarray",
+              "tags": [
+                "Greedy"
+              ]
+            },
+            {
+              "slug": "jump-game",
+              "title": "Jump Game",
+              "tags": [
+                "Greedy"
+              ]
+            },
+            {
+              "slug": "jump-game-ii",
+              "title": "Jump Game II",
+              "tags": [
+                "Greedy"
+              ]
+            },
+            {
+              "slug": "gas-station",
+              "title": "Gas Station",
+              "tags": [
+                "Greedy"
+              ]
+            },
+            {
+              "slug": "hand-of-straights",
+              "title": "Hand of Straights",
+              "tags": [
+                "Greedy"
+              ]
+            },
+            {
+              "slug": "merge-triplets-to-form-target-triplet",
+              "title": "Merge Triplets to Form Target Triplet",
+              "tags": [
+                "Greedy"
+              ]
+            },
+            {
+              "slug": "partition-labels",
+              "title": "Partition Labels",
+              "tags": [
+                "Greedy"
+              ]
+            },
+            {
+              "slug": "valid-parenthesis-string",
+              "title": "Valid Parenthesis String",
+              "tags": [
+                "Greedy"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "graphs",
+          "title": "Graphs",
+          "items": [
+            {
+              "slug": "number-of-islands",
+              "title": "Number of Islands",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "clone-graph",
+              "title": "Clone Graph",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "max-area-of-island",
+              "title": "Max Area of Island",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "pacific-atlantic-water-flow",
+              "title": "Pacific Atlantic Water Flow",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "surrounded-regions",
+              "title": "Surrounded Regions",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "rotting-oranges",
+              "title": "Rotting Oranges",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "walls-and-gates",
+              "title": "Walls And Gates",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "course-schedule",
+              "title": "Course Schedule",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "course-schedule-ii",
+              "title": "Course Schedule II",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "redundant-connection",
+              "title": "Redundant Connection",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "number-of-connected-components-in-an-undirected-graph",
+              "title": "Number of Connected Components In An Undirected Graph",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "graph-valid-tree",
+              "title": "Graph Valid Tree",
+              "tags": [
+                "Graphs"
+              ]
+            },
+            {
+              "slug": "word-ladder",
+              "title": "Word Ladder",
+              "tags": [
+                "Graphs"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "advanced-graphs",
+          "title": "Advanced Graphs",
+          "items": [
+            {
+              "slug": "reconstruct-itinerary",
+              "title": "Reconstruct Itinerary",
+              "tags": [
+                "Advanced Graphs"
+              ]
+            },
+            {
+              "slug": "min-cost-to-connect-all-points",
+              "title": "Min Cost to Connect All Points",
+              "tags": [
+                "Advanced Graphs"
+              ]
+            },
+            {
+              "slug": "network-delay-time",
+              "title": "Network Delay Time",
+              "tags": [
+                "Advanced Graphs"
+              ]
+            },
+            {
+              "slug": "swim-in-rising-water",
+              "title": "Swim In Rising Water",
+              "tags": [
+                "Advanced Graphs"
+              ]
+            },
+            {
+              "slug": "alien-dictionary",
+              "title": "Alien Dictionary",
+              "tags": [
+                "Advanced Graphs"
+              ]
+            },
+            {
+              "slug": "cheapest-flights-within-k-stops",
+              "title": "Cheapest Flights Within K Stops",
+              "tags": [
+                "Advanced Graphs"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "1-d-dp",
+          "title": "1-D DP",
+          "items": [
+            {
+              "slug": "climbing-stairs",
+              "title": "Climbing Stairs",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "min-cost-climbing-stairs",
+              "title": "Min Cost Climbing Stairs",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "house-robber",
+              "title": "House Robber",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "house-robber-ii",
+              "title": "House Robber II",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "longest-palindromic-substring",
+              "title": "Longest Palindromic Substring",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "palindromic-substrings",
+              "title": "Palindromic Substrings",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "decode-ways",
+              "title": "Decode Ways",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "coin-change",
+              "title": "Coin Change",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "maximum-product-subarray",
+              "title": "Maximum Product Subarray",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "word-break",
+              "title": "Word Break",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "longest-increasing-subsequence",
+              "title": "Longest Increasing Subsequence",
+              "tags": [
+                "1-D DP"
+              ]
+            },
+            {
+              "slug": "partition-equal-subset-sum",
+              "title": "Partition Equal Subset Sum",
+              "tags": [
+                "1-D DP"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "2-d-dp",
+          "title": "2-D DP",
+          "items": [
+            {
+              "slug": "unique-paths",
+              "title": "Unique Paths",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "longest-common-subsequence",
+              "title": "Longest Common Subsequence",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "best-time-to-buy-and-sell-stock-with-cooldown",
+              "title": "Best Time to Buy And Sell Stock With Cooldown",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "coin-change-ii",
+              "title": "Coin Change II",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "target-sum",
+              "title": "Target Sum",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "interleaving-string",
+              "title": "Interleaving String",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "longest-increasing-path-in-a-matrix",
+              "title": "Longest Increasing Path In a Matrix",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "distinct-subsequences",
+              "title": "Distinct Subsequences",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "edit-distance",
+              "title": "Edit Distance",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "burst-balloons",
+              "title": "Burst Balloons",
+              "tags": [
+                "2-D DP"
+              ]
+            },
+            {
+              "slug": "regular-expression-matching",
+              "title": "Regular Expression Matching",
+              "tags": [
+                "2-D DP"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "bit-manipulation",
+          "title": "Bit Manipulation",
+          "items": [
+            {
+              "slug": "single-number",
+              "title": "Single Number",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            },
+            {
+              "slug": "number-of-1-bits",
+              "title": "Number of 1 Bits",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            },
+            {
+              "slug": "counting-bits",
+              "title": "Counting Bits",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            },
+            {
+              "slug": "reverse-bits",
+              "title": "Reverse Bits",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            },
+            {
+              "slug": "missing-number",
+              "title": "Missing Number",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            },
+            {
+              "slug": "sum-of-two-integers",
+              "title": "Sum of Two Integers",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            },
+            {
+              "slug": "reverse-integer",
+              "title": "Reverse Integer",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            },
+            {
+              "slug": "hamming-distance",
+              "title": "Hamming-distance",
+              "tags": [
+                "Bit Manipulation"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "math-geometry",
+          "title": "Math & Geometry",
+          "items": [
+            {
+              "slug": "rotate-image",
+              "title": "Rotate Image",
+              "tags": [
+                "Math & Geometry"
+              ]
+            },
+            {
+              "slug": "spiral-matrix",
+              "title": "Spiral Matrix",
+              "tags": [
+                "Math & Geometry"
+              ]
+            },
+            {
+              "slug": "set-matrix-zeroes",
+              "title": "Set Matrix Zeroes",
+              "tags": [
+                "Math & Geometry"
+              ]
+            },
+            {
+              "slug": "happy-number",
+              "title": "Happy Number",
+              "tags": [
+                "Math & Geometry"
+              ]
+            },
+            {
+              "slug": "plus-one",
+              "title": "Plus One",
+              "tags": [
+                "Math & Geometry"
+              ]
+            },
+            {
+              "slug": "pow-x-n",
+              "title": "Pow(x, n)",
+              "tags": [
+                "Math & Geometry"
+              ]
+            },
+            {
+              "slug": "multiply-strings",
+              "title": "Multiply Strings",
+              "tags": [
+                "Math & Geometry"
+              ]
+            },
+            {
+              "slug": "detect-squares",
+              "title": "Detect Squares",
+              "tags": [
+                "Math & Geometry"
+              ]
+            }
+          ]
+        },
+        {
+          "slug": "math",
+          "title": "Math",
+          "items": [
+            {
+              "slug": "factorial",
+              "title": "Factorial",
+              "tags": [
+                "Math",
+                "Recursion"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "data-structures": {
+      "title": "Data Structures",
+      "items": [
+        {
+          "slug": "linked-list",
+          "title": "Linked-list"
+        },
+        {
+          "slug": "doubly-linked-list",
+          "title": "Doubly-Linked-list"
+        },
+        {
+          "slug": "stack",
+          "title": "Stack"
+        },
+        {
+          "slug": "hash-table",
+          "title": "Hash Table"
+        },
+        {
+          "slug": "queue",
+          "title": "Queue"
+        }
+      ]
+    }
+  }
+}

--- a/src/cli/prompts.js
+++ b/src/cli/prompts.js
@@ -1,0 +1,61 @@
+import readline from 'readline/promises'
+
+export function createPrompter({ input, output }) {
+  const rl = readline.createInterface({ input, output })
+
+  return {
+    async ask(message, { defaultValue = '' } = {}) {
+      const suffix = defaultValue ? ` (${defaultValue})` : ''
+      const answer = await rl.question(`${message}${suffix}: `)
+      return answer.trim() || defaultValue
+    },
+
+    async select(message, options) {
+      if (!Array.isArray(options) || options.length === 0) {
+        throw new Error(`No options are available for: ${message}`)
+      }
+
+      output.write(`\n${message}\n`)
+      options.forEach((option, index) => {
+        output.write(`  ${index + 1}. ${option.label}\n`)
+      })
+
+      while (true) {
+        const answer = await rl.question(`Choose [1-${options.length}]: `)
+        const selectedIndex = Number.parseInt(answer, 10)
+
+        if (Number.isInteger(selectedIndex) && selectedIndex >= 1 && selectedIndex <= options.length) {
+          return options[selectedIndex - 1].value
+        }
+
+        output.write('Please enter one of the listed numbers.\n')
+      }
+    },
+
+    async confirm(message, { defaultValue = true } = {}) {
+      const hint = defaultValue ? 'Y/n' : 'y/N'
+
+      while (true) {
+        const answer = (await rl.question(`${message} [${hint}]: `)).trim().toLowerCase()
+
+        if (!answer) {
+          return defaultValue
+        }
+
+        if (['y', 'yes'].includes(answer)) {
+          return true
+        }
+
+        if (['n', 'no'].includes(answer)) {
+          return false
+        }
+
+        output.write('Please answer yes or no.\n')
+      }
+    },
+
+    close() {
+      rl.close()
+    },
+  }
+}

--- a/src/cli/scanner.js
+++ b/src/cli/scanner.js
@@ -1,0 +1,268 @@
+import fs from 'fs'
+import path from 'path'
+
+import {
+  ALGORITHMS_DIR,
+  DATA_STRUCTURES_DIR,
+  IGNORED_DIRECTORY_NAMES,
+  PROJECT_ROOT,
+  SCAFFOLD_MARKER,
+} from './constants.js'
+import {
+  getPythonModuleName,
+  titleFromSlug,
+} from './normalize.js'
+
+function isIgnoredDirectory(entryName) {
+  return IGNORED_DIRECTORY_NAMES.has(entryName) || entryName.startsWith('.')
+}
+
+function listDirectories(directoryPath) {
+  if (!fs.existsSync(directoryPath)) {
+    return []
+  }
+
+  return fs
+    .readdirSync(directoryPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !isIgnoredDirectory(entry.name))
+    .map((entry) => entry.name)
+}
+
+function listFiles(directoryPath) {
+  if (!fs.existsSync(directoryPath)) {
+    return []
+  }
+
+  return fs
+    .readdirSync(directoryPath, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+}
+
+function toProjectRelativePath(filePath) {
+  return path.relative(PROJECT_ROOT, filePath).split(path.sep).join('/')
+}
+
+function isTypeScriptTestFile(fileName) {
+  return fileName.endsWith('.spec.ts') || fileName.endsWith('.test.ts')
+}
+
+function isPythonTestFile(fileName) {
+  return fileName.startsWith('test_') && fileName.endsWith('.py')
+}
+
+function readImplementationStatus(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return 'missing'
+  }
+
+  const preview = fs.readFileSync(filePath, 'utf8')
+
+  return preview.includes(SCAFFOLD_MARKER) ? 'scaffolded' : 'solved'
+}
+
+function getLatestUpdatedAt(paths) {
+  const existingPaths = paths.filter((candidatePath) => candidatePath && fs.existsSync(candidatePath))
+
+  if (existingPaths.length === 0) {
+    return null
+  }
+
+  const latestTimestamp = existingPaths.reduce((latest, candidatePath) => {
+    const modifiedAt = fs.statSync(candidatePath).mtimeMs
+    return Math.max(latest, modifiedAt)
+  }, 0)
+
+  return new Date(latestTimestamp).toISOString()
+}
+
+function buildImplementation(language, solutionPath, testPath) {
+  const updatedAt = getLatestUpdatedAt([solutionPath, testPath])
+
+  return {
+    language,
+    solutionPath: toProjectRelativePath(solutionPath),
+    testPath: testPath ? toProjectRelativePath(testPath) : null,
+    status: readImplementationStatus(solutionPath),
+    updatedAt,
+  }
+}
+
+function scanAlgorithmProblem(categorySlug, problemSlug, problemDirectoryPath) {
+  const files = listFiles(problemDirectoryPath)
+  const implementations = []
+  const pythonModuleName = getPythonModuleName(problemSlug)
+
+  const typeScriptSolutionFileName =
+    files.find((fileName) => fileName === `${problemSlug}.ts`) ??
+    files.find((fileName) => fileName.endsWith('.ts') && !isTypeScriptTestFile(fileName))
+
+  if (typeScriptSolutionFileName) {
+    const typeScriptTestFileName =
+      files.find((fileName) => fileName === `${problemSlug}.spec.ts`) ??
+      files.find((fileName) => fileName === `${problemSlug}.test.ts`) ??
+      files.find((fileName) => isTypeScriptTestFile(fileName))
+
+    implementations.push(
+      buildImplementation(
+        'typescript',
+        path.join(problemDirectoryPath, typeScriptSolutionFileName),
+        typeScriptTestFileName
+          ? path.join(problemDirectoryPath, typeScriptTestFileName)
+          : null
+      )
+    )
+  }
+
+  const pythonSolutionFileName =
+    files.find((fileName) => fileName === `${pythonModuleName}.py`) ??
+    files.find((fileName) => fileName.endsWith('.py') && !isPythonTestFile(fileName))
+
+  if (pythonSolutionFileName) {
+    const pythonTestFileName =
+      files.find((fileName) => fileName === `test_${pythonModuleName}.py`) ??
+      files.find((fileName) => isPythonTestFile(fileName))
+
+    implementations.push(
+      buildImplementation(
+        'python',
+        path.join(problemDirectoryPath, pythonSolutionFileName),
+        pythonTestFileName ? path.join(problemDirectoryPath, pythonTestFileName) : null
+      )
+    )
+  }
+
+  if (implementations.length === 0) {
+    return null
+  }
+
+  const updatedAt = getLatestUpdatedAt(
+    implementations.flatMap((implementation) => [
+      implementation.solutionPath
+        ? path.join(PROJECT_ROOT, implementation.solutionPath)
+        : null,
+      implementation.testPath ? path.join(PROJECT_ROOT, implementation.testPath) : null,
+    ])
+  )
+
+  return {
+    track: 'algorithms',
+    categorySlug,
+    title: titleFromSlug(problemSlug),
+    slug: problemSlug,
+    implementations,
+    updatedAt,
+  }
+}
+
+function scanDataStructure(structureSlug, structureDirectoryPath) {
+  const rootFiles = listFiles(structureDirectoryPath)
+  const implementations = []
+  const pythonModuleName = getPythonModuleName(structureSlug)
+
+  const typeScriptSolutionFileName =
+    rootFiles.find((fileName) => fileName === `${structureSlug}.ts`) ??
+    rootFiles.find((fileName) => fileName.endsWith('.ts') && !isTypeScriptTestFile(fileName)) ??
+    null
+
+  if (typeScriptSolutionFileName) {
+    const testsDirectoryPath = path.join(structureDirectoryPath, '__tests__')
+    const testFiles = listFiles(testsDirectoryPath)
+
+    const typeScriptTestFileName =
+      testFiles.find((fileName) => fileName === `${structureSlug}.spec.ts`) ??
+      testFiles.find((fileName) => fileName === `${structureSlug}.test.ts`) ??
+      testFiles.find((fileName) => isTypeScriptTestFile(fileName))
+
+    implementations.push(
+      buildImplementation(
+        'typescript',
+        path.join(structureDirectoryPath, typeScriptSolutionFileName),
+        typeScriptTestFileName
+          ? path.join(testsDirectoryPath, typeScriptTestFileName)
+          : null
+      )
+    )
+  }
+
+  const pythonSolutionFileName =
+    rootFiles.find((fileName) => fileName === `${pythonModuleName}.py`) ??
+    rootFiles.find((fileName) => fileName.endsWith('.py') && !isPythonTestFile(fileName)) ??
+    null
+
+  if (pythonSolutionFileName) {
+    const pythonTestFileName =
+      rootFiles.find((fileName) => fileName === `test_${pythonModuleName}.py`) ??
+      rootFiles.find((fileName) => isPythonTestFile(fileName))
+
+    implementations.push(
+      buildImplementation(
+        'python',
+        path.join(structureDirectoryPath, pythonSolutionFileName),
+        pythonTestFileName ? path.join(structureDirectoryPath, pythonTestFileName) : null
+      )
+    )
+  }
+
+  if (implementations.length === 0) {
+    return null
+  }
+
+  const updatedAt = getLatestUpdatedAt(
+    implementations.flatMap((implementation) => [
+      implementation.solutionPath
+        ? path.join(PROJECT_ROOT, implementation.solutionPath)
+        : null,
+      implementation.testPath ? path.join(PROJECT_ROOT, implementation.testPath) : null,
+    ])
+  )
+
+  return {
+    track: 'data-structures',
+    title: titleFromSlug(structureSlug),
+    slug: structureSlug,
+    implementations,
+    updatedAt,
+  }
+}
+
+export function scanRepository({
+  algorithmsDir = ALGORITHMS_DIR,
+  dataStructuresDir = DATA_STRUCTURES_DIR,
+} = {}) {
+  const algorithms = []
+
+  for (const categorySlug of listDirectories(algorithmsDir)) {
+    const categoryDirectoryPath = path.join(algorithmsDir, categorySlug)
+
+    for (const problemSlug of listDirectories(categoryDirectoryPath)) {
+      const problemDirectoryPath = path.join(categoryDirectoryPath, problemSlug)
+      const scannedProblem = scanAlgorithmProblem(
+        categorySlug,
+        problemSlug,
+        problemDirectoryPath
+      )
+
+      if (scannedProblem) {
+        algorithms.push(scannedProblem)
+      }
+    }
+  }
+
+  const dataStructures = []
+
+  for (const structureSlug of listDirectories(dataStructuresDir)) {
+    const structureDirectoryPath = path.join(dataStructuresDir, structureSlug)
+    const scannedStructure = scanDataStructure(structureSlug, structureDirectoryPath)
+
+    if (scannedStructure) {
+      dataStructures.push(scannedStructure)
+    }
+  }
+
+  return {
+    algorithms,
+    dataStructures,
+    scannedAt: new Date().toISOString(),
+  }
+}

--- a/src/cli/state.js
+++ b/src/cli/state.js
@@ -1,0 +1,291 @@
+import {
+  DEFAULT_NEXT_LIMIT,
+  DEFAULT_RECENT_LIMIT,
+  LANGUAGES,
+  TRACKS,
+} from './constants.js'
+import {
+  getAlgorithmCategories,
+  getDataStructureItems,
+} from './catalog.js'
+import { titleFromSlug } from './normalize.js'
+
+function determineItemStatus(implementations) {
+  if (implementations.some((implementation) => implementation.status === 'solved')) {
+    return 'solved'
+  }
+
+  if (implementations.some((implementation) => implementation.status === 'scaffolded')) {
+    return 'scaffolded'
+  }
+
+  return 'remaining'
+}
+
+function compareByTitle(leftItem, rightItem) {
+  return String(leftItem.title).localeCompare(String(rightItem.title))
+}
+
+function compareByUpdatedAt(leftItem, rightItem) {
+  return new Date(rightItem.updatedAt ?? 0).getTime() - new Date(leftItem.updatedAt ?? 0).getTime()
+}
+
+function buildMergedItem(baseItem, scannedItem, extras = {}) {
+  const implementations = scannedItem?.implementations ?? []
+  const status = determineItemStatus(implementations)
+
+  return {
+    ...baseItem,
+    implementations,
+    languages: implementations.map((implementation) => implementation.language),
+    status,
+    updatedAt: scannedItem?.updatedAt ?? null,
+    source: extras.source ?? 'catalog',
+    track: extras.track,
+    categorySlug: extras.categorySlug ?? null,
+    categoryTitle: extras.categoryTitle ?? null,
+  }
+}
+
+function summarizeItems(items) {
+  return {
+    total: items.length,
+    solved: items.filter((item) => item.status === 'solved').length,
+    scaffolded: items.filter((item) => item.status === 'scaffolded').length,
+    remaining: items.filter((item) => item.status === 'remaining').length,
+  }
+}
+
+function buildLanguageSummary(algorithmCategories, dataStructureItems) {
+  const summary = LANGUAGES.map((language) => ({
+    ...language,
+    solved: 0,
+    scaffolded: 0,
+  }))
+
+  const allItems = [
+    ...algorithmCategories.flatMap((category) => category.items),
+    ...dataStructureItems,
+  ]
+
+  for (const item of allItems) {
+    for (const implementation of item.implementations) {
+      const languageSummary = summary.find(
+        (candidate) => candidate.id === implementation.language
+      )
+
+      if (!languageSummary) {
+        continue
+      }
+
+      if (implementation.status === 'solved') {
+        languageSummary.solved += 1
+      }
+
+      if (implementation.status === 'scaffolded') {
+        languageSummary.scaffolded += 1
+      }
+    }
+  }
+
+  return summary
+}
+
+export function buildProjectState(catalog, scanResults) {
+  const scannedAlgorithmsByKey = new Map(
+    scanResults.algorithms.map((item) => [`${item.categorySlug}:${item.slug}`, item])
+  )
+
+  const algorithmCategories = getAlgorithmCategories(catalog).map((category) => {
+    const items = category.items
+      .map((item) => {
+        const key = `${category.slug}:${item.slug}`
+
+        return buildMergedItem(item, scannedAlgorithmsByKey.get(key), {
+          source: 'catalog',
+          track: 'algorithms',
+          categorySlug: category.slug,
+          categoryTitle: category.title,
+        })
+      })
+      .sort(compareByTitle)
+
+    return {
+      ...category,
+      items,
+      summary: summarizeItems(items),
+    }
+  })
+
+  const seenAlgorithmKeys = new Set(
+    algorithmCategories.flatMap((category) =>
+      category.items.map((item) => `${category.slug}:${item.slug}`)
+    )
+  )
+
+  for (const scannedItem of scanResults.algorithms) {
+    const key = `${scannedItem.categorySlug}:${scannedItem.slug}`
+
+    if (seenAlgorithmKeys.has(key)) {
+      continue
+    }
+
+    let targetCategory = algorithmCategories.find(
+      (category) => category.slug === scannedItem.categorySlug
+    )
+
+    if (!targetCategory) {
+      targetCategory = {
+        slug: scannedItem.categorySlug,
+        title: titleFromSlug(scannedItem.categorySlug),
+        items: [],
+        summary: {
+          total: 0,
+          solved: 0,
+          scaffolded: 0,
+          remaining: 0,
+        },
+        source: 'discovered',
+      }
+
+      algorithmCategories.push(targetCategory)
+    }
+
+    targetCategory.items.push(
+      buildMergedItem(
+        {
+          slug: scannedItem.slug,
+          title: scannedItem.title,
+          tags: [targetCategory.title],
+        },
+        scannedItem,
+        {
+          source: 'discovered',
+          track: 'algorithms',
+          categorySlug: targetCategory.slug,
+          categoryTitle: targetCategory.title,
+        }
+      )
+    )
+
+    targetCategory.items.sort(compareByTitle)
+    targetCategory.summary = summarizeItems(targetCategory.items)
+  }
+
+  const algorithmSummary = summarizeItems(
+    algorithmCategories.flatMap((category) => category.items)
+  )
+
+  const scannedDataStructuresBySlug = new Map(
+    scanResults.dataStructures.map((item) => [item.slug, item])
+  )
+
+  const dataStructureItems = getDataStructureItems(catalog)
+    .map((item) =>
+      buildMergedItem(item, scannedDataStructuresBySlug.get(item.slug), {
+        source: 'catalog',
+        track: 'data-structures',
+      })
+    )
+    .sort(compareByTitle)
+
+  const seenDataStructures = new Set(dataStructureItems.map((item) => item.slug))
+
+  for (const scannedItem of scanResults.dataStructures) {
+    if (seenDataStructures.has(scannedItem.slug)) {
+      continue
+    }
+
+    dataStructureItems.push(
+      buildMergedItem(
+        {
+          slug: scannedItem.slug,
+          title: scannedItem.title,
+        },
+        scannedItem,
+        {
+          source: 'discovered',
+          track: 'data-structures',
+        }
+      )
+    )
+  }
+
+  dataStructureItems.sort(compareByTitle)
+  const dataStructureSummary = summarizeItems(dataStructureItems)
+
+  const trackSummary = TRACKS.map((track) => {
+    if (track.id === 'algorithms') {
+      return {
+        ...track,
+        ...algorithmSummary,
+      }
+    }
+
+    return {
+      ...track,
+      ...dataStructureSummary,
+    }
+  })
+
+  const overall = trackSummary.reduce(
+    (runningSummary, track) => ({
+      total: runningSummary.total + track.total,
+      solved: runningSummary.solved + track.solved,
+      scaffolded: runningSummary.scaffolded + track.scaffolded,
+      remaining: runningSummary.remaining + track.remaining,
+    }),
+    {
+      total: 0,
+      solved: 0,
+      scaffolded: 0,
+      remaining: 0,
+    }
+  )
+
+  const languageSummary = buildLanguageSummary(
+    algorithmCategories,
+    dataStructureItems
+  )
+
+  const allItems = [
+    ...algorithmCategories.flatMap((category) => category.items),
+    ...dataStructureItems,
+  ]
+
+  const recentActivity = allItems
+    .filter((item) => item.updatedAt)
+    .sort(compareByUpdatedAt)
+    .slice(0, DEFAULT_RECENT_LIMIT)
+
+  const activeItems = allItems
+    .filter((item) => item.status === 'scaffolded')
+    .sort(compareByUpdatedAt)
+    .slice(0, DEFAULT_NEXT_LIMIT)
+
+  const nextItems = algorithmCategories
+    .flatMap((category) => category.items)
+    .filter((item) => item.status === 'remaining')
+    .slice(0, DEFAULT_NEXT_LIMIT)
+
+  const discoveredItems = allItems.filter((item) => item.source === 'discovered')
+
+  return {
+    generatedAt: new Date().toISOString(),
+    overall,
+    algorithms: {
+      categories: algorithmCategories,
+      ...algorithmSummary,
+    },
+    dataStructures: {
+      items: dataStructureItems,
+      ...dataStructureSummary,
+    },
+    tracks: trackSummary,
+    languages: languageSummary,
+    recentActivity,
+    activeItems,
+    nextItems,
+    discoveredItems,
+  }
+}

--- a/src/cli/templates.js
+++ b/src/cli/templates.js
@@ -1,0 +1,61 @@
+import { SCAFFOLD_MARKER } from './constants.js'
+import {
+  getPythonModuleName,
+  toClassName,
+  toFunctionName,
+  toPythonFunctionName,
+} from './normalize.js'
+
+function buildAlgorithmTypeScriptTemplate({ itemTitle, categoryTitle, itemSlug }) {
+  const functionName = toFunctionName(itemSlug)
+
+  return {
+    solution: `/**\n * ${SCAFFOLD_MARKER}\n * Problem: ${itemTitle}\n * Category: ${categoryTitle}\n *\n * Add the original prompt, constraints, and example cases here.\n * Remove the scaffold marker above when the solution is implemented.\n */\nexport function ${functionName}(...args: unknown[]): unknown {\n  throw new Error('Not implemented')\n}\n`,
+    test: `import { ${functionName} } from './${itemSlug}'\n\ndescribe('${itemTitle}', () => {\n  it.skip('wires up the starter implementation', () => {\n    expect(typeof ${functionName}).toBe('function')\n  })\n\n  it.todo('replace this placeholder with the official sample case')\n})\n`,
+  }
+}
+
+function buildAlgorithmPythonTemplate({ itemTitle, categoryTitle, itemSlug }) {
+  const functionName = toPythonFunctionName(itemSlug)
+  const moduleName = getPythonModuleName(itemSlug)
+
+  return {
+    solution: `\"\"\"\n${SCAFFOLD_MARKER}\nProblem: ${itemTitle}\nCategory: ${categoryTitle}\n\nAdd the original prompt, constraints, and example cases here.\nRemove the scaffold marker above when the solution is implemented.\n\"\"\"\n\n\ndef ${functionName}(*args):\n    raise NotImplementedError('Not implemented')\n`,
+    test: `import pytest\nfrom ${moduleName} import ${functionName}\n\n\n@pytest.mark.skip(reason='Replace this placeholder with the official sample case')\ndef test_${functionName}_is_wired():\n    assert callable(${functionName})\n`,
+  }
+}
+
+function buildDataStructureTypeScriptTemplate({ itemTitle, itemSlug }) {
+  const className = toClassName(itemSlug)
+
+  return {
+    solution: `/**\n * ${SCAFFOLD_MARKER}\n * Data structure: ${itemTitle}\n *\n * Add notes about the API, invariants, and sample operations here.\n * Remove the scaffold marker above when the implementation is complete.\n */\nexport default class ${className}<T = unknown> {\n  constructor() {}\n}\n`,
+    test: `import ${className} from '../${itemSlug}'\n\ndescribe('${itemTitle}', () => {\n  it.skip('creates a starter instance', () => {\n    expect(new ${className}()).toBeInstanceOf(${className})\n  })\n\n  it.todo('replace this placeholder with behavior-driven tests')\n})\n`,
+  }
+}
+
+function buildDataStructurePythonTemplate({ itemTitle, itemSlug }) {
+  const className = toClassName(itemSlug)
+  const moduleName = getPythonModuleName(itemSlug)
+
+  return {
+    solution: `\"\"\"\n${SCAFFOLD_MARKER}\nData structure: ${itemTitle}\n\nAdd notes about the API, invariants, and sample operations here.\nRemove the scaffold marker above when the implementation is complete.\n\"\"\"\n\n\nclass ${className}:\n    def __init__(self):\n        raise NotImplementedError('Not implemented')\n`,
+    test: `import pytest\nfrom ${moduleName} import ${className}\n\n\n@pytest.mark.skip(reason='Replace this placeholder with behavior-driven tests')\ndef test_${moduleName}_is_wired():\n    assert ${className} is not None\n`,
+  }
+}
+
+export function buildTemplateSet(request) {
+  if (request.track === 'algorithms' && request.language === 'typescript') {
+    return buildAlgorithmTypeScriptTemplate(request)
+  }
+
+  if (request.track === 'algorithms' && request.language === 'python') {
+    return buildAlgorithmPythonTemplate(request)
+  }
+
+  if (request.track === 'data-structures' && request.language === 'typescript') {
+    return buildDataStructureTypeScriptTemplate(request)
+  }
+
+  return buildDataStructurePythonTemplate(request)
+}

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -1,0 +1,249 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { spawnSync } from 'child_process'
+
+const repoRoot = path.resolve(__dirname, '../..')
+const cliPath = path.join(repoRoot, 'cli.js')
+const tempRoots: string[] = []
+
+function writeFile(targetPath: string, content: string) {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+  fs.writeFileSync(targetPath, content)
+}
+
+function createTempProject(catalog: unknown) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dsa-cli-'))
+  tempRoots.push(tempRoot)
+
+  writeFile(path.join(tempRoot, 'readme.md'), '# temp project\n')
+  writeFile(
+    path.join(tempRoot, 'src', 'cli', 'problem-catalog.json'),
+    `${JSON.stringify(catalog, null, 2)}\n`
+  )
+  fs.mkdirSync(path.join(tempRoot, 'src', 'algorithms'), { recursive: true })
+  fs.mkdirSync(path.join(tempRoot, 'src', 'data-structures'), { recursive: true })
+
+  return tempRoot
+}
+
+function runCli(tempRoot: string, args: string[]) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      DSA_CLI_ROOT: tempRoot,
+      DSA_CLI_CATALOG_PATH: path.join(tempRoot, 'src', 'cli', 'problem-catalog.json'),
+    },
+    encoding: 'utf8',
+  })
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    fs.rmSync(tempRoots.pop() as string, { recursive: true, force: true })
+  }
+})
+
+describe('CLI integration', () => {
+  it('renders dashboard JSON with solved, scaffolded, and remaining counts', () => {
+    const tempRoot = createTempProject({
+      version: 1,
+      tracks: {
+        algorithms: {
+          title: 'Algorithms',
+          categories: [
+            {
+              slug: 'arrays',
+              title: 'Arrays',
+              items: [
+                { slug: 'solved-problem', title: 'Solved Problem', tags: ['Arrays'] },
+                {
+                  slug: 'in-progress-problem',
+                  title: 'In Progress Problem',
+                  tags: ['Arrays'],
+                },
+                {
+                  slug: 'remaining-problem',
+                  title: 'Remaining Problem',
+                  tags: ['Arrays'],
+                },
+              ],
+            },
+          ],
+        },
+        'data-structures': {
+          title: 'Data Structures',
+          items: [{ slug: 'stack', title: 'Stack' }],
+        },
+      },
+    })
+
+    writeFile(
+      path.join(
+        tempRoot,
+        'src',
+        'algorithms',
+        'arrays',
+        'solved-problem',
+        'solved-problem.ts'
+      ),
+      "export function solvedProblem() {\n  return 'done'\n}\n"
+    )
+    writeFile(
+      path.join(
+        tempRoot,
+        'src',
+        'algorithms',
+        'arrays',
+        'in-progress-problem',
+        'in-progress-problem.ts'
+      ),
+      "/**\n * @dsa-cli-status scaffold\n */\nexport function inProgressProblem() {\n  throw new Error('Not implemented')\n}\n"
+    )
+    writeFile(
+      path.join(tempRoot, 'src', 'data-structures', 'stack', 'stack.ts'),
+      'export default class Stack {}\n'
+    )
+
+    const result = runCli(tempRoot, ['dashboard', '--json'])
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+
+    const payload = JSON.parse(result.stdout)
+
+    expect(payload.overall).toEqual({
+      total: 4,
+      solved: 2,
+      scaffolded: 1,
+      remaining: 1,
+    })
+    expect(payload.algorithms.solved).toBe(1)
+    expect(payload.algorithms.scaffolded).toBe(1)
+    expect(payload.algorithms.remaining).toBe(1)
+    expect(payload.dataStructures.solved).toBe(1)
+  })
+
+  it('generates a TypeScript algorithm scaffold and tracks it in the catalog', () => {
+    const tempRoot = createTempProject({
+      version: 1,
+      tracks: {
+        algorithms: {
+          title: 'Algorithms',
+          categories: [{ slug: 'arrays', title: 'Arrays', items: [] }],
+        },
+        'data-structures': {
+          title: 'Data Structures',
+          items: [],
+        },
+      },
+    })
+
+    const result = runCli(tempRoot, [
+      'generate',
+      '--track',
+      'algorithms',
+      '--category',
+      'arrays',
+      '--problem',
+      'Fresh Problem',
+      '--language',
+      'typescript',
+    ])
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toContain('Scaffold created successfully.')
+
+    const solutionPath = path.join(
+      tempRoot,
+      'src',
+      'algorithms',
+      'arrays',
+      'fresh-problem',
+      'fresh-problem.ts'
+    )
+    const testPath = path.join(
+      tempRoot,
+      'src',
+      'algorithms',
+      'arrays',
+      'fresh-problem',
+      'fresh-problem.spec.ts'
+    )
+
+    expect(fs.existsSync(solutionPath)).toBe(true)
+    expect(fs.existsSync(testPath)).toBe(true)
+    expect(fs.readFileSync(solutionPath, 'utf8')).toContain('@dsa-cli-status scaffold')
+
+    const catalog = JSON.parse(
+      fs.readFileSync(path.join(tempRoot, 'src', 'cli', 'problem-catalog.json'), 'utf8')
+    )
+    expect(catalog.tracks.algorithms.categories[0].items).toEqual([
+      {
+        slug: 'fresh-problem',
+        title: 'Fresh Problem',
+        tags: ['Arrays'],
+      },
+    ])
+  })
+
+  it('generates a Python data-structure scaffold and adds it to the catalog', () => {
+    const tempRoot = createTempProject({
+      version: 1,
+      tracks: {
+        algorithms: {
+          title: 'Algorithms',
+          categories: [],
+        },
+        'data-structures': {
+          title: 'Data Structures',
+          items: [],
+        },
+      },
+    })
+
+    const result = runCli(tempRoot, [
+      'generate',
+      '--track',
+      'data-structures',
+      '--problem',
+      'Binary Tree',
+      '--language',
+      'python',
+    ])
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+
+    const solutionPath = path.join(
+      tempRoot,
+      'src',
+      'data-structures',
+      'binary-tree',
+      'binary_tree.py'
+    )
+    const testPath = path.join(
+      tempRoot,
+      'src',
+      'data-structures',
+      'binary-tree',
+      'test_binary_tree.py'
+    )
+
+    expect(fs.existsSync(solutionPath)).toBe(true)
+    expect(fs.existsSync(testPath)).toBe(true)
+    expect(fs.readFileSync(solutionPath, 'utf8')).toContain('@dsa-cli-status scaffold')
+
+    const catalog = JSON.parse(
+      fs.readFileSync(path.join(tempRoot, 'src', 'cli', 'problem-catalog.json'), 'utf8')
+    )
+    expect(catalog.tracks['data-structures'].items).toEqual([
+      {
+        slug: 'binary-tree',
+        title: 'Binary Tree',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
This pull request introduces a new CLI dashboard and scaffolding system for the repository, providing a command-line interface for tracking progress and generating starter files for algorithms and data structures. The changes add a robust CLI entrypoint, argument parsing, dashboard rendering, catalog management, and normalization utilities, along with updates to documentation and project configuration.

**CLI System Implementation**

* Added a new CLI entrypoint in `cli.js`, handling broken pipe errors and invoking the main CLI logic via `runCli`.
* Implemented the core CLI logic in `src/cli/index.js`, including argument parsing, command routing (`dashboard`, `generate`, `help`), interactive mode, and integration with dashboard rendering and scaffold generation.

**Dashboard and Catalog Management**

* Created catalog utilities in `src/cli/catalog.js` for loading, saving, and managing algorithm and data structure items, with validation and item counting.
* Added dashboard rendering logic in `src/cli/dashboard.js`, including progress bars, summaries, activity lists, and colorized output.
* Introduced color utilities in `src/cli/colors.js` for ANSI color output.

**Configuration and Utilities**

* Defined CLI constants and environment overrides in `src/cli/constants.js`, including directory paths, scaffold marker, and supported tracks/languages.
* Added normalization and naming utilities in `src/cli/normalize.js` for slugs, track/language/category aliases, and code identifier generation.

**Documentation and Project Setup**

* Updated `package.json` to register the CLI as a bin script (`dsa`), add a local CLI script, and support npm linking.
* Expanded `readme.md` with instructions for running the CLI dashboard and generating scaffolds, including usage examples and explanation of the scaffold marker.